### PR TITLE
main.cpp: Update Setup function to feed Watchdog once for init

### DIFF
--- a/HGD4_reversed/src/main.cpp
+++ b/HGD4_reversed/src/main.cpp
@@ -43,6 +43,8 @@ void setup() {
   Wire.begin();
   //set i2c pins 
   pinMode(15, OUTPUT);
+  //initial watchdog feeding, necessary to avoid reset. this has to be in this position because otherwise i2c dies
+  in1_handler();
 }
 
 void loop() {


### PR DESCRIPTION
This is needed because the Watchdog IC expects 1 cycle of toggling DONE before it itself has toggled WAKE, if this is not done the WD will trigger and the System resets regularly

The fix is calling in1_setup(); once in setup function.